### PR TITLE
Update filter defaults for broader applicability

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -385,10 +385,9 @@
             <div style="margin-bottom: 20px;">
                 <label for="team-status-filter" style="display: block; margin-bottom: 5px; font-weight: bold;">Filter Teams:</label>
                 <select id="team-status-filter" class="btn" style="width: 200px;" onchange="filterTeams()">
-                    <option value="all">All Teams</option>
+                    <option value="all" selected>All Teams</option>
                     <option value="active">Active Teams Only</option>
                     <option value="archived">Archived Teams Only</option>
-                    <option value="cobs" selected>Cobs Teams Only</option>
                 </select>
             </div>
             
@@ -403,8 +402,8 @@
                 <div style="margin-bottom: 15px;">
                     <label for="game-filter" style="display: block; margin-bottom: 5px; font-weight: bold;">Show Games:</label>
                     <select id="game-filter" class="btn" style="width: 180px;" onchange="filterGames()">
-                        <option value="next" selected>Next Game Only</option>
-                        <option value="all">All Upcoming Games</option>
+                        <option value="next">Next Game Only</option>
+                        <option value="all" selected>All Upcoming Games</option>
                         <option value="all-states">All Games (Any State)</option>
                     </select>
                 </div>


### PR DESCRIPTION
## Summary
- Set team filter default to "All Teams" instead of "Cobs Teams Only"  
- Set game filter default to "All Upcoming Games" instead of "Next Game Only"
- Remove "Cobs Teams Only" filter option

## Changes
Makes the app more universally useful for any baseball team by using broader default filters instead of specific team-focused options.

## Test plan
- [ ] Verify team filter defaults to "All Teams" on page load
- [ ] Verify game filter defaults to "All Upcoming Games" on page load  
- [ ] Confirm "Cobs Teams Only" option is no longer available
- [ ] Test that filtering still works correctly with new defaults

🤖 Generated with [Claude Code](https://claude.ai/code)