### PR TITLE
Docs: Enforce mandatory branch workflow in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,28 @@ heroku open
 - **Self-signed certificates**: Browser warnings expected in local development
 - **TeamSnap API rate limiting**: Not yet implemented for production use
 
+## Git Workflow (MANDATORY)
+
+### 🚨 CRITICAL: Branch Workflow
+- **NEVER commit directly to main branch**
+- **ALWAYS create a feature branch first** - NO EXCEPTIONS
+- Even for small fixes, typos, or documentation - use branches and PRs
+
+**Process:**
+1. Create branch: `git checkout -b feature/description` or `fix/bug-name`
+2. Make changes and commit
+3. Push branch: `git push -u origin branch-name`
+4. Create PR: `gh pr create`
+5. Wait for CI/CD checks to pass
+6. **Ask user before merging** - Never merge without approval
+
+**Branch naming:**
+- `feature/description` - New features
+- `fix/bug-name` - Bug fixes
+- `docs/topic` - Documentation updates
+
+See global `~/Code/CLAUDE.md` for complete Git workflow documentation.
+
 ## Important Notes
 
 - **HTTPS Required**: TeamSnap OAuth requires HTTPS for redirect URIs


### PR DESCRIPTION
## Problem

The Git workflow documentation was ambiguous about when to use branches. It mentioned \"create a new branch when starting new work\" but didn't explicitly forbid direct commits to main. This led to accidental direct commits (e.g., commit 41e6827).

## Solution

Added explicit **🚨 CRITICAL** sections to both CLAUDE.md files making it crystal clear:
- **NEVER commit directly to main** - NO EXCEPTIONS
- **ALWAYS create a feature branch first**
- Even for small fixes, typos, hotfixes - use branches

## Changes

### Global ~/Code/CLAUDE.md
- Added "🚨 CRITICAL: Branch Workflow (MANDATORY)" section
- Updated Standard Development Process to start with "Branch" step
- Added branch naming conventions
- Emphasized: Never merge without user approval

### Project CLAUDE.md
- Added "Git Workflow (MANDATORY)" section
- Includes quick reference with branch naming conventions
- References global CLAUDE.md for complete documentation

## Benefits

1. **No more accidental main commits** - Rules are now explicit
2. **Consistent workflow** - Clear step-by-step process
3. **Better change tracking** - All changes go through PR review
4. **CI/CD validation** - All changes tested before merging

## Files Changed

- `CLAUDE.md` - Added Git Workflow section (22 lines)

## Related

- Triggered by: Direct commit to main (41e6827) when fixing demo mode bug
- Global file: `~/Code/CLAUDE.md` (also updated but not in this repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)