### PR TITLE
Docs: Replace SonarQube badges with SonarCloud equivalents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Multi-Sport Lineup Manager
 
-[![Quality Gate Status](http://44.206.255.230:9000/api/project_badges/measure?project=multisport-lineup-app&metric=alert_status)](http://44.206.255.230:9000/dashboard?id=multisport-lineup-app)
-[![Coverage](http://44.206.255.230:9000/api/project_badges/measure?project=multisport-lineup-app&metric=coverage)](http://44.206.255.230:9000/dashboard?id=multisport-lineup-app)
-[![Bugs](http://44.206.255.230:9000/api/project_badges/measure?project=multisport-lineup-app&metric=bugs)](http://44.206.255.230:9000/dashboard?id=multisport-lineup-app)
-[![Vulnerabilities](http://44.206.255.230:9000/api/project_badges/measure?project=multisport-lineup-app&metric=vulnerabilities)](http://44.206.255.230:9000/dashboard?id=multisport-lineup-app)
-[![Code Smells](http://44.206.255.230:9000/api/project_badges/measure?project=multisport-lineup-app&metric=code_smells)](http://44.206.255.230:9000/dashboard?id=multisport-lineup-app)
-[![Security Rating](http://44.206.255.230:9000/api/project_badges/measure?project=multisport-lineup-app&metric=security_rating)](http://44.206.255.230:9000/dashboard?id=multisport-lineup-app)
-[![Maintainability Rating](http://44.206.255.230:9000/api/project_badges/measure?project=multisport-lineup-app&metric=sqale_rating)](http://44.206.255.230:9000/dashboard?id=multisport-lineup-app)
-[![Reliability Rating](http://44.206.255.230:9000/api/project_badges/measure?project=multisport-lineup-app&metric=reliability_rating)](http://44.206.255.230:9000/dashboard?id=multisport-lineup-app)
-[![Lines of Code](http://44.206.255.230:9000/api/project_badges/measure?project=multisport-lineup-app&metric=ncloc)](http://44.206.255.230:9000/dashboard?id=multisport-lineup-app)
-[![Duplicated Lines (%)](http://44.206.255.230:9000/api/project_badges/measure?project=multisport-lineup-app&metric=duplicated_lines_density)](http://44.206.255.230:9000/dashboard?id=multisport-lineup-app)
-[![Technical Debt](http://44.206.255.230:9000/api/project_badges/measure?project=multisport-lineup-app&metric=sqale_index)](http://44.206.255.230:9000/dashboard?id=multisport-lineup-app)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=adamkwhite_multisport-lineup-app&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=adamkwhite_multisport-lineup-app)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=adamkwhite_multisport-lineup-app&metric=coverage)](https://sonarcloud.io/summary/new_code?id=adamkwhite_multisport-lineup-app)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=adamkwhite_multisport-lineup-app&metric=bugs)](https://sonarcloud.io/summary/new_code?id=adamkwhite_multisport-lineup-app)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=adamkwhite_multisport-lineup-app&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=adamkwhite_multisport-lineup-app)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=adamkwhite_multisport-lineup-app&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=adamkwhite_multisport-lineup-app)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=adamkwhite_multisport-lineup-app&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=adamkwhite_multisport-lineup-app)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=adamkwhite_multisport-lineup-app&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=adamkwhite_multisport-lineup-app)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=adamkwhite_multisport-lineup-app&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=adamkwhite_multisport-lineup-app)
+[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=adamkwhite_multisport-lineup-app&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=adamkwhite_multisport-lineup-app)
+[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=adamkwhite_multisport-lineup-app&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=adamkwhite_multisport-lineup-app)
+[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=adamkwhite_multisport-lineup-app&metric=sqale_index)](https://sonarcloud.io/summary/new_code?id=adamkwhite_multisport-lineup-app)
 
 A web application that connects to the TeamSnap API to automatically generate baseball fielding positions for upcoming games.
 


### PR DESCRIPTION
## Summary
Updates README badges to point to SonarCloud instead of self-hosted SonarQube.

**Changes:**
- ✅ Replaced all 11 badge URLs with SonarCloud equivalents
- ✅ Updated all badge links to point to SonarCloud dashboard
- ✅ Removed all references to `44.206.255.230:9000`

**Badges Updated:**
1. Quality Gate Status
2. Coverage
3. Bugs
4. Vulnerabilities
5. Code Smells
6. Security Rating
7. Maintainability Rating
8. Reliability Rating
9. Lines of Code
10. Duplicated Lines (%)
11. Technical Debt

All badges now link to: https://sonarcloud.io/summary/new_code?id=adamkwhite_multisport-lineup-app

**Related:**
- Issue #72: Add README badges and public visibility features
- PRD: `docs/features/sonarcloud-public-migration-PLANNED/sonarcloud-migration-prd.md`
- Previous PR: #74 (CI/CD migration)

**Testing:**
- ✅ Verified no references to `44.206.255.230` remain in README
- Badges will display after merge (SonarCloud has already analyzed main branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)