### PR TITLE
Fix: Add main branch SonarCloud analysis

### DIFF
--- a/.github/workflows/main-branch-quality.yml
+++ b/.github/workflows/main-branch-quality.yml
@@ -1,0 +1,62 @@
+name: Main Branch Quality Analysis
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  sonarcloud:
+    name: SonarCloud Analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for better analysis
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Install Node.js dependencies
+        run: |
+          npm install
+
+      - name: Run Python tests with coverage
+        run: |
+          pytest tests/unit/ tests/edge_cases/ --cov=app --cov=sports --cov-report=xml:coverage.xml --cov-report=term-missing
+
+      - name: Run JavaScript tests with coverage
+        run: |
+          npm test -- --coverage --watchAll=false
+
+      - name: Copy coverage files for SonarCloud
+        run: |
+          # Copy Jest coverage from CI directory structure
+          if [ -f "coverage/lcov.info" ]; then
+            cp coverage/lcov.info lcov.info
+            echo "✅ Copied coverage/lcov.info to lcov.info"
+          fi
+          # Verify coverage files exist
+          ls -la coverage.xml lcov.info 2>/dev/null || echo "⚠️ Coverage files not found"
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Problem
README badges show "Quality gate not computed" because SonarCloud has never analyzed the main branch - only PRs.

The current `pr-validation.yml` workflow only triggers on `pull_request` events, so:
- ❌ Main branch never analyzed
- ❌ Overall Code metrics unavailable
- ❌ README badges can't display data

## Solution
Add `main-branch-quality.yml` workflow that runs on pushes to main:
- ✅ Runs tests with coverage
- ✅ Sends analysis to SonarCloud
- ✅ Populates Overall Code metrics
- ✅ Enables README badges to display actual data

## Result
After this PR merges and the workflow runs:
- 📊 README badges will show actual metrics (coverage %, bug count, etc.)
- ✅ Quality gate will be computed for main branch
- 📈 Overall Code dashboard will be fully populated

## Testing
Once merged, the workflow will trigger automatically and analyze main branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)