### PR TITLE
Fix: Add sonar.host.url for main branch analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey=adamkwhite_multisport-lineup-app
 sonar.organization=adamkwhite
+sonar.host.url=https://sonarcloud.io
 sonar.python.version=3.12
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.javascript.lcov.reportPaths=lcov.info


### PR DESCRIPTION
## Problem
Main branch SonarCloud analysis is failing with error:
```
Expected URL scheme 'http' or 'https' but no scheme was found
```

This prevents badges from populating with actual metrics.

## Root Cause
The `sonarqube-scan-action@v6` requires explicit `sonar.host.url` configuration, even for SonarCloud.

## Solution
Add `sonar.host.url=https://sonarcloud.io` to `sonar-project.properties`

## Testing
- ✅ PR analysis will verify syntax is correct
- ✅ After merge, main branch workflow will run successfully
- ✅ Badges will populate with actual code quality metrics

## Related
- SonarCloud migration (Issues #70-73)
- PR #78 (added main branch workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)