### PR TITLE
chore: add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ test-results/
 # Local Claude settings (may contain internal URLs)
 .claude/settings.local.json
 lineup-venv/
+.venv/


### PR DESCRIPTION
## Summary
- Added `.venv/` to project `.gitignore` to match standardized venv naming convention

## Test plan
- [x] No functional changes, gitignore only

🤖 Generated with [Claude Code](https://claude.com/claude-code)