### PR TITLE
chore(ci): add paths-ignore to workflows that lacked one

### DIFF
--- a/.github/workflows/main-branch-quality.yml
+++ b/.github/workflows/main-branch-quality.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
 
 permissions:
   contents: read

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Adds `paths-ignore` to the `push` trigger in `main-branch-quality.yml` and the `pull_request` trigger in `pr-validation.yml`, matching the canonical pattern used in `project_template`.

## Why

These two workflows were previously the orphans without a `paths-ignore` filter. PRs that only touch documentation (`*.md`, `docs/**`), `LICENSE`, `.gitignore`, or `.github/**` artifacts were running the full Python/JS test + SonarCloud gates against zero changed source files. This change skips those runs entirely, keeping CI runtime focused on real code changes.

## Changes

- `.github/workflows/main-branch-quality.yml` — added `paths-ignore` under `on.push`
- `.github/workflows/pr-validation.yml` — added `paths-ignore` under `on.pull_request`

The filter list matches the project_template idiom:
`['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']`

## Test plan

- [x] Pre-commit hooks pass locally
- [ ] CI runs on this PR (it modifies `.github/**` so the new filter would skip it on subsequent pushes — but the existing run on this PR is the validation that the YAML parses correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)