### PR TITLE
chore(ci): add workflow concurrency block

### DIFF
--- a/.github/workflows/main-branch-quality.yml
+++ b/.github/workflows/main-branch-quality.yml
@@ -1,5 +1,9 @@
 name: Main Branch Quality Analysis
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,5 +1,9 @@
 name: PR Validation
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
## Summary

- Adds `concurrency:` to `main-branch-quality.yml` and `pr-validation.yml`
- Cancels in-progress runs when new commits are pushed to the same ref
- Prevents wasted CI minutes on superseded runs during rapid iteration

## Test plan

- [ ] Verify workflows still trigger normally on push/PR
- [ ] Verify a second push cancels the first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)